### PR TITLE
chore: use travis for releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,25 @@
 language: python
 dist: xenial
-matrix:
+jobs:
   include:
     - { python: "3.6",   env: "TOXENV=py36" }
     - { python: "3.7",   env: "TOXENV=py37" }
+
+    - stage: PyPI Release
+      if: tag IS present
+      python: "3.7"
+      env: []
+      before_install: skip
+      install: skip
+      script: skip
+      deploy:
+        provider: pypi
+        user: itajaja
+        on:
+          tags: true
+        distributions: sdist bdist_wheel
+        password:
+          secure: "Kdp9xxTk36kbLhDfa1b2kg51swzagJKNnNtQSAM/CWqLc96D0nQ20Niin2T6Mb3ge9xv4KrXPMQTaqld2hH44flZ+ydryHi4KfmJ+WZ3pTxpvFx4T9rouafkhFR8G9E0g1v6FLAasDuXDXk+n2Be6Y+lEoQ2domHRDr6pFw01UfnSrdBWYjH90Znq0tsp6zUkKmWcRHo+a7AnfIfByLYgTWcMw9BNUHOLYUf6Hw9wWL4tMGWyaICsCP8cI0GRK7CYxfA5qCzOP8onahp1TAo3YPy5eNKINbVEWcu4ELY2Cuu/kBWYjLoZ1K0qVixmbXTnQTSRtZGnSt0/KLHhPJZgzuYbLSN/C/tiirCYtWG0eE0J1fQIN0rzktkCN9cQ3Yra441tGEwND3IK4G7Rq/wJ5tQX52bDvgwqgKe7YSCpk2HQs5p206sTFy3WnzMNX7gov1oiLx1TGbE7B0t4ZL+TGlB0/aXuMixvB8TOJYM70UDesNsjOHD+FkQcEJ5BtAucDW/35LeKLi2LDV5lEl27sjpVtM1ljwfBLKHKG4BzUkfK45KzDxVUIb3596hGScY2LGYI211Jx8pXGatOmEZlWPyD+hexV15naqLWseuT7Fd7t5FHyYVGZeWM5waxODB+2vcYoMA4l4rCWO37diAv2suJgc1wrKx7VWA1FMPdqc="
 cache:
   directories:
     - $HOME/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,5 @@ setup(
     ),
     python_requires=">=3.6",
     entry_points={"console_scripts": ("fourmat = fourmat:cli",)},
-    cmdclass={
-        "clean": system("rm -rf build dist *.egg-info"),
-        "package": system("python setup.py sdist bdist_wheel"),
-        "publish": system("twine upload dist/*"),
-        "release": system("python setup.py clean package publish"),
-        "test": system("tox"),
-    },
+    cmdclass={"test": system("tox")},
 )


### PR DESCRIPTION
Use Travis CI's rather undocumented build stages feature to automatically release to PyPI upon pushing a tag. Using build stages ensures that the release only happens if all other builds pass.

**ACTION REQUIRED**:

Need to add encrypted PyPI PW:

```
brew install travis
travis encrypt
... enter PyPI password then hit Ctrl+d...
```

Copy the value into the `secure` field.