### PR TITLE
[WIP] feat: add separate pre-commit hooks for fix and format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,24 @@
 - id: fourmat
   name: fourmat
-  description: 'Fourmat: Batteries-included linting and autoformatting'
+  description: 'Deprecated. Use `fourmat-fix`.'
   entry: fourmat fix
   language: python
   language_version: python3
   require_serial: true  # https://github.com/ambv/black/pull/675
+  types: [python]
+- id: fourmat-fix
+  name: fourmat fix
+  description: 'Format code with fourmat.'
+  entry: fourmat fix
+  language: python
+  language_version: python3
+  require_serial: true  # https://github.com/ambv/black/pull/675
+  types: [python]
+- id: fourmat-check
+  name: fourmat check
+  description: 'Check syntax with fourmat.'
+  entry: fourmat check
+  language: python
+  language_version: python3
+  require_serial: true
   types: [python]


### PR DESCRIPTION
There's currently no pre-commit hook for running `fourmat check`. This exposes `fourmat-fix` and `fourmat-check` as separate hooks.

TODO: 

- [ ] Test this out
- [ ] Update docs

Will do these when I have some extra time. Just opening for feedback.