### PR TITLE
fix: remove py39 from target versions (not yet supported)

### DIFF
--- a/fourmat/assets/pyproject.toml
+++ b/fourmat/assets/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38']


### PR DESCRIPTION
The latest black version doesn't appear to support py39 yet. I get an error when running with the latest config

```

Error: Invalid value for '-t' / '--target-version': invalid choice: py39. (choose from py27, py33, py34, py35, py36, py37, py38)
```