### PR TITLE
Upgrade black from 20.8b1 to 21.6b0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     package_data={"fourmat": ("assets/*.*", "assets/.*")},
     install_requires=(
         "click>=7",
-        "black==20.8b1",
+        "black==21.6b0",
         "flake8-bugbear>=21,<22",
         "flake8>=3,<4",
         "isort>=5,<6",


### PR DESCRIPTION
This change has been tested for isort compatibility in the `ButterflyNetwork/software` repository here: https://github.com/ButterflyNetwork/software/pull/21055