### PR TITLE
fix: bump black to 26.3.1 (arbitrary file write via cache filename)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="fourmat",
-    version="2.0.0",
+    version="2.0.1",
     description="A library for batteries-included linting and autoformatting",
     url="https://github.com/4Catalyzer/fourmat",
     author="Giacomo Tagliabue",
@@ -24,7 +24,7 @@ setup(
     package_data={"fourmat": ["assets/*.*", "assets/.*"]},
     install_requires=(
         "click>=8",
-        "black==25.1.0",
+        "black==26.3.1",
         "flake8-bugbear>=24,<25",
         "flake8>=7,<8",
         "isort>=6,<7",


### PR DESCRIPTION
## fix: bump black to 26.3.1 (arbitrary file write via cache filename)

### Summary
Bumps the pinned `black` from `25.1.0` to `26.3.1` to address a security vulnerability, and releases as `2.0.1`.

### Why
`black` versions `< 26.3.1` are vulnerable to **arbitrary file writes from unsanitized user input in the cache file name** (GHSA / Dependabot high-severity advisory). Since `fourmat` pins `black` with an exact version (`black==25.1.0`), downstream consumers cannot upgrade black without updating fourmat.

### Changes
- `setup.py`: `black==25.1.0` → `black==26.3.1`
- `setup.py`: `version` `2.0.0` → `2.0.1`

### Testing
- [x] `fourmat check` — exit 0 (self-lint passes with black 26.3.1)
- [x] `pytest test/` — 5 passed
- [x] `black --version` → 26.3.1

Note: running `fourmat check` on Python 3.10 emits black's standard AST safety-check warning (config targets py312); this is environment-related and non-fatal (exit 0). CI's tox matrix runs py310/311/312 separately.